### PR TITLE
Add FastAPI-based content moderation API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+app.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Smart-Content-Moderator-API
+# Smart Content Moderator API
+
+FastAPI-based service that analyses text or image content for inappropriate material. It stores moderation results in a SQLite database, sends Slack and email alerts for unsafe content, and exposes analytics endpoints.
+
+## Features
+- Async FastAPI application
+- Asynchronous SQLAlchemy models
+- OpenAI integration for content classification (falls back to heuristic if no API key)
+- Slack and Brevo (email) notifications
+- Background task processing for image moderation
+- Basic analytics endpoint
+
+## Setup
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+## API
+- `POST /api/v1/moderate/text`
+- `POST /api/v1/moderate/image`
+- `GET /api/v1/analytics/summary?user=user@example.com`
+
+Set environment variables `OPENAI_API_KEY`, `SLACK_WEBHOOK_URL`, and `BREVO_API_KEY` for full functionality.

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,14 @@
+import os
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+from sqlalchemy.orm import declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./app.db")
+
+engine = create_async_engine(DATABASE_URL, echo=False, future=True)
+async_session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+Base = declarative_base()
+
+async def init_db() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+
+from .db import init_db
+from .routers import analytics, moderation
+
+app = FastAPI(title="Smart Content Moderator API")
+
+app.include_router(moderation.router)
+app.include_router(analytics.router)
+
+
+@app.on_event("startup")
+async def on_startup():
+    await init_db()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,44 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text, Float
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+
+from .db import Base
+
+
+class ModerationRequest(Base):
+    __tablename__ = "moderation_requests"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_email = Column(String, index=True)
+    content_type = Column(String)
+    content_hash = Column(String, unique=True)
+    status = Column(String, default="pending")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    result = relationship("ModerationResult", back_populates="request", uselist=False)
+    notifications = relationship("NotificationLog", back_populates="request")
+
+
+class ModerationResult(Base):
+    __tablename__ = "moderation_results"
+
+    id = Column(Integer, primary_key=True, index=True)
+    request_id = Column(Integer, ForeignKey("moderation_requests.id"))
+    classification = Column(String)
+    confidence = Column(Float)
+    reasoning = Column(Text)
+    llm_response = Column(Text)
+
+    request = relationship("ModerationRequest", back_populates="result")
+
+
+class NotificationLog(Base):
+    __tablename__ = "notification_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    request_id = Column(Integer, ForeignKey("moderation_requests.id"))
+    channel = Column(String)
+    status = Column(String)
+    sent_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    request = relationship("ModerationRequest", back_populates="notifications")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,3 @@
+from . import analytics, moderation
+
+__all__ = ["moderation", "analytics"]

--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import Dict
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import async_session
+from ..models import ModerationRequest, ModerationResult
+from ..schemas import ModerationSummary
+
+router = APIRouter(prefix="/api/v1", tags=["analytics"])
+
+
+async def get_session():
+    async with async_session() as session:
+        yield session
+
+
+@router.get("/analytics/summary", response_model=ModerationSummary)
+async def analytics_summary(user: str, session: AsyncSession = Depends(get_session)):
+    stmt = (
+        select(ModerationResult.classification, func.count(ModerationResult.id))
+        .join(ModerationRequest)
+        .where(ModerationRequest.user_email == user)
+        .group_by(ModerationResult.classification)
+    )
+    res = await session.execute(stmt)
+    counts = {row[0]: row[1] for row in res.all()}
+    total = sum(counts.values())
+    return ModerationSummary(
+        user=user,
+        total_requests=total,
+        by_classification=counts,
+        generated_at=datetime.utcnow(),
+    )

--- a/app/routers/moderation.py
+++ b/app/routers/moderation.py
@@ -1,0 +1,142 @@
+import hashlib
+
+from fastapi import APIRouter, BackgroundTasks, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import async_session
+from ..models import ModerationRequest, ModerationResult, NotificationLog
+from ..schemas import (
+    ImageModerationRequest,
+    ModerationResponse,
+    TextModerationRequest,
+)
+from ..services.moderation import analyze_image, analyze_text
+from ..services.notification import send_email_alert, send_slack_alert
+
+router = APIRouter(prefix="/api/v1", tags=["moderation"])
+
+
+async def get_session():
+    async with async_session() as session:
+        yield session
+
+
+@router.post("/moderate/text", response_model=ModerationResponse)
+async def moderate_text(
+    payload: TextModerationRequest, session: AsyncSession = Depends(get_session)
+):
+    content_hash = hashlib.sha256(payload.text.encode()).hexdigest()
+    req = ModerationRequest(
+        user_email=payload.email,
+        content_type="text",
+        content_hash=content_hash,
+        status="pending",
+    )
+    session.add(req)
+    await session.commit()
+    await session.refresh(req)
+
+    classification, confidence, reasoning, raw = await analyze_text(payload.text)
+
+    req.status = "completed"
+    result = ModerationResult(
+        request_id=req.id,
+        classification=classification,
+        confidence=confidence,
+        reasoning=reasoning,
+        llm_response=raw,
+    )
+    session.add(result)
+    await session.commit()
+
+    if classification != "safe":
+        message = f"Inappropriate content detected: {classification}"
+        slack_status = await send_slack_alert(message)
+        session.add(
+            NotificationLog(
+                request_id=req.id,
+                channel="slack",
+                status="sent" if slack_status else "failed",
+            )
+        )
+        email_status = await send_email_alert(
+            payload.email, "Content moderation alert", message
+        )
+        session.add(
+            NotificationLog(
+                request_id=req.id,
+                channel="email",
+                status="sent" if email_status else "failed",
+            )
+        )
+        await session.commit()
+
+    return ModerationResponse(
+        request_id=req.id,
+        classification=classification,
+        confidence=confidence,
+        reasoning=reasoning,
+        status=req.status,
+    )
+
+
+@router.post("/moderate/image")
+async def moderate_image(
+    payload: ImageModerationRequest,
+    background_tasks: BackgroundTasks,
+    session: AsyncSession = Depends(get_session),
+):
+    content_hash = hashlib.sha256(payload.image_base64.encode()).hexdigest()
+    req = ModerationRequest(
+        user_email=payload.email,
+        content_type="image",
+        content_hash=content_hash,
+        status="pending",
+    )
+    session.add(req)
+    await session.commit()
+    await session.refresh(req)
+
+    background_tasks.add_task(
+        process_image_moderation, req.id, payload.image_base64, payload.email
+    )
+
+    return {"request_id": req.id, "status": "processing"}
+
+
+async def process_image_moderation(request_id: int, image_b64: str, email: str):
+    async with async_session() as session:
+        classification, confidence, reasoning, raw = await analyze_image(image_b64)
+        req = await session.get(ModerationRequest, request_id)
+        req.status = "completed"
+        result = ModerationResult(
+            request_id=request_id,
+            classification=classification,
+            confidence=confidence,
+            reasoning=reasoning,
+            llm_response=raw,
+        )
+        session.add(result)
+        await session.commit()
+
+        if classification != "safe":
+            message = f"Inappropriate image detected: {classification}"
+            slack_status = await send_slack_alert(message)
+            session.add(
+                NotificationLog(
+                    request_id=request_id,
+                    channel="slack",
+                    status="sent" if slack_status else "failed",
+                )
+            )
+            email_status = await send_email_alert(
+                email, "Content moderation alert", message
+            )
+            session.add(
+                NotificationLog(
+                    request_id=request_id,
+                    channel="email",
+                    status="sent" if email_status else "failed",
+                )
+            )
+            await session.commit()

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from typing import Dict, Optional
+
+from pydantic import BaseModel, EmailStr
+
+
+class TextModerationRequest(BaseModel):
+    email: EmailStr
+    text: str
+
+
+class ImageModerationRequest(BaseModel):
+    email: EmailStr
+    image_base64: str
+
+
+class ModerationResponse(BaseModel):
+    request_id: int
+    classification: str
+    confidence: float
+    reasoning: Optional[str]
+    status: str
+
+
+class ModerationSummary(BaseModel):
+    user: EmailStr
+    total_requests: int
+    by_classification: Dict[str, int]
+    generated_at: datetime

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,3 @@
+from . import moderation, notification
+
+__all__ = ["moderation", "notification"]

--- a/app/services/moderation.py
+++ b/app/services/moderation.py
@@ -1,0 +1,43 @@
+import os
+from typing import Tuple
+
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+
+async def analyze_text(text: str) -> Tuple[str, float, str, str]:
+    """Analyze text content and return classification and related info."""
+    if not openai.api_key:
+        lower = text.lower()
+        if any(word in lower for word in ["spam", "harass", "toxic"]):
+            classification = "toxic"
+            confidence = 0.9
+        else:
+            classification = "safe"
+            confidence = 0.8
+        reasoning = "Heuristic analysis without OpenAI key."
+        return classification, confidence, reasoning, "{}"
+
+    prompt = (
+        "Classify the following content into one of [toxic, spam, harassment, safe] "
+        "and explain briefly: \n" + text
+    )
+    try:
+        completion = await openai.ChatCompletion.acreate(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=50,
+        )
+        message = completion.choices[0].message["content"].strip()
+        classification = message.split("\n")[0].split()[0].lower()
+        reasoning = message
+        confidence = 0.75
+        return classification, confidence, reasoning, str(completion)
+    except Exception as exc:  # pragma: no cover - network errors
+        return "error", 0.0, str(exc), "{}"
+
+
+async def analyze_image(image_b64: str) -> Tuple[str, float, str, str]:
+    """Placeholder for image analysis; uses text analyzer on base64 string."""
+    return await analyze_text(image_b64)

--- a/app/services/notification.py
+++ b/app/services/notification.py
@@ -1,0 +1,39 @@
+import os
+from typing import Optional
+
+import httpx
+
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+BREVO_API_KEY = os.getenv("BREVO_API_KEY")
+BREVO_API_URL = "https://api.brevo.com/v3/smtp/email"
+
+
+async def send_slack_alert(message: str) -> bool:
+    if not SLACK_WEBHOOK_URL:
+        print("Slack webhook not configured", message)
+        return False
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.post(SLACK_WEBHOOK_URL, json={"text": message})
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+
+async def send_email_alert(to_email: str, subject: str, content: str) -> bool:
+    if not BREVO_API_KEY:
+        print(f"Email alert to {to_email}: {subject} - {content}")
+        return False
+    headers = {"api-key": BREVO_API_KEY, "Content-Type": "application/json"}
+    data = {
+        "sender": {"name": "Moderator", "email": "noreply@example.com"},
+        "to": [{"email": to_email}],
+        "subject": subject,
+        "htmlContent": content,
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.post(BREVO_API_URL, json=data, headers=headers)
+            return resp.status_code < 300
+        except Exception:
+            return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+sqlalchemy[asyncio]
+aiosqlite
+pydantic[email]
+httpx
+openai
+pytest

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db import init_db
+
+
+@pytest.fixture(scope="module")
+def client():
+    asyncio.run(init_db())
+    with TestClient(app) as c:
+        yield c
+
+
+def test_moderate_text(client):
+    response = client.post(
+        "/api/v1/moderate/text",
+        json={"email": "test@example.com", "text": "This is safe"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["classification"] in {"safe", "toxic", "spam", "harassment", "error"}
+    assert "request_id" in data


### PR DESCRIPTION
## Summary
- implement async FastAPI app with text & image moderation endpoints
- integrate OpenAI-based classifier with Slack/email notifications
- provide analytics endpoint and project setup docs

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a21369c42083308da05a3b935554fe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced Smart Content Moderator API with text and image moderation endpoints.
  - Added background processing for image moderation.
  - Implemented notifications via Slack and email for unsafe content.
  - Provided analytics summary endpoint by user.
  - Enabled async database setup and persistence.

- Documentation
  - Expanded README with project overview, features, setup steps, environment variables, and API usage examples.

- Tests
  - Added test covering text moderation endpoint response and structure.

- Chores
  - Updated dependencies for API, async ORM, HTTP client, and testing.
  - Expanded .gitignore to exclude caches and local database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->